### PR TITLE
Add snap support

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -1,0 +1,24 @@
+name: wyvern
+base: core18
+version: git
+summary: Commandline gog downloader client
+description: Command-line tool written in rust that is meant to make downloading GOG games and associated activities easier and faster on linux.
+
+grade: stable
+confinement: strict
+
+apps:
+  wyvern:
+    command: wyvern
+    plugs: [ network, home ]
+
+parts:
+  wyvern:
+    plugin: rust
+    source: .
+    build-packages:
+      - build-essential
+      - libssl-dev
+      - pkg-config
+    stage-packages:
+      - libssl1.0.0


### PR DESCRIPTION
This would add initial snap support for your application. You could use this to automatically build your project on build.snapcraft.io whenever you push to `master`. Builds would be made for various architectures such as AMD64 and ARM, and the snap could be installed from the snap store on any Linux distribution which supports snaps.

Builds can be automatically released to the `--edge` channel in the store. If you are happy with the builds, they can be promoted to the `--beta` or `--candidate` channels for testing. Ultimately, they could be released to the `--stable` channel.

There are some issues to work out, though, before I'd call the snap version "stable". For example, due to snap confinement it may be difficult to install `.desktop` files in the correct place. We'd need to think about how to manage that.

Thanks for making this application! I'm looking forward to downloading my games overnight on my Raspberry Pi!